### PR TITLE
Single item contains

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,8 @@ assert_that!(Some(1), not(none::<u8>()));
 
 ```rust
 assert_that!(&vec!(1, 2, 3), contains(vec!(1, 2)));
-assert_that!(&vec!(1, 2, 3), not(contains(vec!(4i))));
+assert_that!(&vec!(1, 2, 3), contains(1));
+assert_that!(&vec!(1, 2, 3), not(contains(4i)));
 
 assert_that!(&vec!(1, 2, 3), contains(vec!(1, 2, 3)).exactly());
 assert_that!(&vec!(1, 2, 3), not(contains(vec!(1, 2)).exactly()));

--- a/src/matchers/contains.rs
+++ b/src/matchers/contains.rs
@@ -25,6 +25,16 @@ pub struct Contains<T> {
 }
 
 impl<T> Contains<T> {
+  /// Constructs new `Contains` matcher with the default options: order is not checked and
+  /// actual vector can have more items.
+  pub fn new(items: Vec<T>) -> Self {
+    Self {
+      items,
+      exactly: false,
+      in_order: false,
+    }
+  }
+
   pub fn exactly(mut self) -> Contains<T> {
     self.exactly = true;
     self
@@ -33,6 +43,18 @@ impl<T> Contains<T> {
   pub fn in_order(mut self) -> Contains<T> {
     self.in_order = true;
     self
+  }
+}
+
+impl<T> From<Vec<T>> for Contains<T> {
+  fn from(items: Vec<T>) -> Contains<T> {
+    Contains::new(items)
+  }
+}
+
+impl<T> From<T> for Contains<T> {
+  fn from(item: T) -> Contains<T> {
+    Contains::new(vec![item])
   }
 }
 
@@ -102,10 +124,10 @@ fn is_next_index(current_index: usize, previous_index: &Option<usize>) -> bool {
   true
 }
 
-pub fn contains<T>(items: Vec<T>) -> Contains<T> {
-  Contains {
-    items,
-    exactly: false,
-    in_order: false,
-  }
+/// Creates matcher that checks if actual data contains give item(s).
+pub fn contains<T, I>(item: I) -> Contains<T>
+where
+  I: Into<Contains<T>>,
+{
+  item.into()
 }

--- a/tests/contain.rs
+++ b/tests/contain.rs
@@ -27,6 +27,12 @@ mod contains {
   }
 
   #[test]
+  fn single_item_contains() {
+    assert_that!(&vec![1, 2, 3], contains(2));
+    assert_that!(&vec![1, 2, 3], not(contains(4)));
+  }
+
+  #[test]
   fn vec_contains_exactly() {
     assert_that!(&vec![1, 2, 3], contains(vec![1, 2, 3]).exactly());
     assert_that!(&vec![1, 2, 3], not(contains(vec![1, 2]).exactly()));


### PR DESCRIPTION
Makes contains matcher generic so that we could use it for both: vecs and single items, e.g.
```
conains(vec![1, 2])
contains(1)
```

See: https://github.com/Valloric/hamcrest2-rust/issues/3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/hamcrest2-rust/4)
<!-- Reviewable:end -->
