### PR TITLE
Fix rustfmt error

### DIFF
--- a/src/matchers/path_exists.rs
+++ b/src/matchers/path_exists.rs
@@ -61,7 +61,8 @@ impl<'a> Matcher<&'a Path> for PathExists {
     expect(
       fs::metadata(actual).is_ok(),
       format!("{} was missing", actual.display()),
-    ).and(self.match_path_type(actual))
+    )
+    .and(self.match_path_type(actual))
   }
 }
 


### PR DESCRIPTION
Fixes travis build because of changed rustfmt behaviour. Would be nice to see a green badge in the Readme!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/hamcrest2-rust/5)
<!-- Reviewable:end -->
