### PR TITLE
Fixes equal_to through rollback

### DIFF
--- a/src/matchers/equal_to.rs
+++ b/src/matchers/equal_to.rs
@@ -10,45 +10,37 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-use std::borrow::Borrow;
 use std::fmt;
-use std::marker::PhantomData;
 
 use core::*;
 
-pub struct EqualTo<T, D> {
+pub struct EqualTo<T> {
   expected: T,
-  marker: PhantomData<D>,
 }
 
-impl<T, D> fmt::Display for EqualTo<T, D>
+impl<T> fmt::Display for EqualTo<T>
 where
   T: fmt::Debug,
-  D: fmt::Debug,
 {
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
     self.expected.fmt(f)
   }
 }
 
-impl<T, U, B> Matcher<B> for EqualTo<U, T>
+impl<T, U> Matcher<T> for EqualTo<U>
 where
   U: PartialEq<T> + fmt::Debug,
   T: fmt::Debug,
-  B: Borrow<T>,
 {
-  fn matches(&self, actual: B) -> MatchResult {
-    if self.expected.eq(actual.borrow()) {
+  fn matches(&self, actual: T) -> MatchResult {
+    if self.expected.eq(&actual) {
       success()
     } else {
-      Err(format!("was {:?}", actual.borrow()))
+      Err(format!("was {:?}", actual))
     }
   }
 }
 
-pub fn equal_to<T, D>(expected: T) -> EqualTo<T, D> {
-  EqualTo {
-    expected,
-    marker: PhantomData,
-  }
+pub fn equal_to<T>(expected: T) -> EqualTo<T> {
+  EqualTo { expected }
 }

--- a/tests/compared_to.rs
+++ b/tests/compared_to.rs
@@ -25,7 +25,17 @@ mod compared_to {
   #[should_panic]
   fn unsuccessful_less_than() {
     assert_that!(4, is(less_than(3)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_less_than_ref() {
     assert_that!(&4, is(less_than(3)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_less_than_mut() {
     assert_that!(&mut 4, is(less_than(3)));
   }
 
@@ -33,7 +43,17 @@ mod compared_to {
   #[should_panic]
   fn less_than_is_not_equal() {
     assert_that!(2, is(less_than(2)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn less_than_is_not_equal_ref() {
     assert_that!(&2, is(less_than(2)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn less_than_is_not_equal_mut() {
     assert_that!(&mut 2, is(less_than(2)));
   }
 
@@ -48,7 +68,17 @@ mod compared_to {
   #[should_panic]
   fn unsuccessful_greater_than() {
     assert_that!(1, is(greater_than(3)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_greater_than_ref() {
     assert_that!(&1, is(greater_than(3)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_greater_than_mut() {
     assert_that!(&mut 1, is(greater_than(3)));
   }
 
@@ -56,7 +86,17 @@ mod compared_to {
   #[should_panic]
   fn greater_than_is_not_equal() {
     assert_that!(2, is(greater_than(2)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn greater_than_is_not_equal_ref() {
     assert_that!(&2, is(greater_than(2)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn greater_than_is_not_equal_mut() {
     assert_that!(&mut 2, is(greater_than(2)));
   }
 
@@ -74,7 +114,17 @@ mod compared_to {
   #[should_panic]
   fn unsuccessful_less_than_or_equal() {
     assert_that!(4, is(less_than_or_equal_to(3)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_less_than_or_equal_ref() {
     assert_that!(&4, is(less_than_or_equal_to(3)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_less_than_or_equal_mut() {
     assert_that!(&mut 4, is(less_than_or_equal_to(3)));
   }
 
@@ -92,8 +142,17 @@ mod compared_to {
   #[should_panic]
   fn unsuccessful_greater_than_or_equal() {
     assert_that!(4, is(greater_than_or_equal_to(5)));
-    assert_that!(&4, is(greater_than_or_equal_to(5)));
-    assert_that!(&mut 4, is(greater_than_or_equal_to(5)));
   }
 
+  #[test]
+  #[should_panic]
+  fn unsuccessful_greater_than_or_equal_ref() {
+    assert_that!(&4, is(greater_than_or_equal_to(5)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_greater_than_or_equal_mut() {
+    assert_that!(&mut 4, is(greater_than_or_equal_to(5)));
+  }
 }

--- a/tests/equal_to.rs
+++ b/tests/equal_to.rs
@@ -53,10 +53,35 @@ mod equal_to {
   #[should_panic]
   fn unsuccessful_match() {
     assert_that!(2, is(equal_to(1)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_match_ref() {
     assert_that!(&2, is(equal_to(1)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_match_mut() {
     assert_that!(&mut 2, is(equal_to(1)));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_match_short() {
     assert_that!(2, eq(1));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_match_short_ref() {
     assert_that!(&2, eq(1));
+  }
+
+  #[test]
+  #[should_panic]
+  fn unsuccessful_match_short_mut() {
     assert_that!(&mut 2, eq(1));
   }
 

--- a/tests/equal_to.rs
+++ b/tests/equal_to.rs
@@ -59,4 +59,30 @@ mod equal_to {
     assert_that!(&2, eq(1));
     assert_that!(&mut 2, eq(1));
   }
+
+  #[test]
+  fn equality_of_strings() {
+    assert_that!("", is(equal_to("")));
+    assert_that!("", is(equal_to(String::new())));
+    assert_that!(String::new(), is(equal_to("")));
+    assert_that!("", is(equal_to(String::new())));
+  }
+
+  #[test]
+  fn equality_of_floats_slice_owned() {
+    let slice = [1.0, 2.0, 3.0];
+    assert_that!(slice, eq(&[1.0, 2.0, 3.0]));
+  }
+
+  #[test]
+  fn equality_of_floats_slice_ref() {
+    let slice = [1.0, 2.0, 3.0];
+    assert_that!(&slice, eq(&[1.0, 2.0, 3.0]));
+  }
+
+  #[test]
+  fn equality_of_floats_slice_mut() {
+    let mut slice = [1.0, 2.0, 3.0];
+    assert_that!(&mut slice, eq(&[1.0, 2.0, 3.0]));
+  }
 }

--- a/tests/equal_to.rs
+++ b/tests/equal_to.rs
@@ -32,21 +32,21 @@ mod equal_to {
   #[test]
   fn equality_with_special_partial_eq() {
     assert_that!(A(1), eq(B(1)));
-    assert_that!(&A(1), eq(B(1)));
-    assert_that!(&mut A(1), eq(B(1)));
+    // assert_that!(&A(1), eq(B(1)));
+    // assert_that!(&mut A(1), eq(B(1)));
     assert_that!(B(1), eq(A(1)));
-    assert_that!(&B(1), eq(A(1)));
-    assert_that!(&mut B(1), eq(A(1)));
+    // assert_that!(&B(1), eq(A(1)));
+    // assert_that!(&mut B(1), eq(A(1)));
   }
 
   #[test]
   fn equality_of_ints() {
     assert_that!(1, is(equal_to(1)));
-    assert_that!(&1, is(equal_to(1)));
-    assert_that!(&mut 1, is(equal_to(1)));
+    // assert_that!(&1, is(equal_to(1)));
+    // assert_that!(&mut 1, is(equal_to(1)));
     assert_that!(1, eq(1));
-    assert_that!(&1, eq(1));
-    assert_that!(&mut 1, eq(1));
+    // assert_that!(&1, eq(1));
+    // assert_that!(&mut 1, eq(1));
   }
 
   #[test]
@@ -55,17 +55,17 @@ mod equal_to {
     assert_that!(2, is(equal_to(1)));
   }
 
-  #[test]
-  #[should_panic]
-  fn unsuccessful_match_ref() {
-    assert_that!(&2, is(equal_to(1)));
-  }
+  // #[test]
+  // #[should_panic]
+  // fn unsuccessful_match_ref() {
+  //   assert_that!(&2, is(equal_to(1)));
+  // }
 
-  #[test]
-  #[should_panic]
-  fn unsuccessful_match_mut() {
-    assert_that!(&mut 2, is(equal_to(1)));
-  }
+  // #[test]
+  // #[should_panic]
+  // fn unsuccessful_match_mut() {
+  //   assert_that!(&mut 2, is(equal_to(1)));
+  // }
 
   #[test]
   #[should_panic]
@@ -73,17 +73,17 @@ mod equal_to {
     assert_that!(2, eq(1));
   }
 
-  #[test]
-  #[should_panic]
-  fn unsuccessful_match_short_ref() {
-    assert_that!(&2, eq(1));
-  }
-
-  #[test]
-  #[should_panic]
-  fn unsuccessful_match_short_mut() {
-    assert_that!(&mut 2, eq(1));
-  }
+  // #[test]
+  // #[should_panic]
+  // fn unsuccessful_match_short_ref() {
+  //   assert_that!(&2, eq(1));
+  // }
+  //
+  // #[test]
+  // #[should_panic]
+  // fn unsuccessful_match_short_mut() {
+  //   assert_that!(&mut 2, eq(1));
+  // }
 
   #[test]
   fn equality_of_strings() {
@@ -93,11 +93,11 @@ mod equal_to {
     assert_that!("", is(equal_to(String::new())));
   }
 
-  #[test]
-  fn equality_of_floats_slice_owned() {
-    let slice = [1.0, 2.0, 3.0];
-    assert_that!(slice, eq(&[1.0, 2.0, 3.0]));
-  }
+  // #[test]
+  // fn equality_of_floats_slice_owned() {
+  //   let slice = [1.0, 2.0, 3.0];
+  //   assert_that!(slice, eq(&[1.0, 2.0, 3.0]));
+  // }
 
   #[test]
   fn equality_of_floats_slice_ref() {

--- a/tests/regex.rs
+++ b/tests/regex.rs
@@ -28,7 +28,11 @@ mod regex {
   #[should_panic]
   fn unsuccessful_match() {
     assert_that!("abc", matches_regex(r"\d"));
-    assert_that!("abc".to_owned(), matches_regex(r"\d"));
   }
 
+  #[test]
+  #[should_panic]
+  fn unsuccessful_match_owned() {
+    assert_that!("abc".to_owned(), matches_regex(r"\d"));
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/Valloric/hamcrest2-rust/issues/7 through removing support for references. Maybe somebody has an idea on how to add the functionality that I have commented in the tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/hamcrest2-rust/8)
<!-- Reviewable:end -->
