### PR TITLE
contains in_order matcher: Fix bug with repeated characters.

### DIFF
--- a/src/matchers/contains.rs
+++ b/src/matchers/contains.rs
@@ -101,27 +101,12 @@ fn contains_in_order<T: fmt::Debug + PartialEq>(
   actual: &[T],
   items: &[T],
 ) -> bool {
-  let mut previous = None;
-
-  for item in items.iter() {
-    match actual.iter().position(|a| *item == *a) {
-      Some(current) => {
-        if !is_next_index(current, &previous) {
-          return false;
-        }
-        previous = Some(current);
-      }
-      None => return false,
+  for start_idx in 0..=(actual.len() - items.len()) {
+    if items == &actual[start_idx..start_idx + items.len()] {
+      return true;
     }
   }
-  true
-}
-
-fn is_next_index(current_index: usize, previous_index: &Option<usize>) -> bool {
-  if let Some(index) = *previous_index {
-    return current_index == index + 1;
-  }
-  true
+  false
 }
 
 /// Creates matcher that checks if actual data contains give item(s).

--- a/tests/contains.rs
+++ b/tests/contains.rs
@@ -40,7 +40,11 @@ mod contains {
 
   #[test]
   fn it_contains_elements_in_order() {
+    // Sanity check.
     assert_that!(&[1, 2, 3], contains(vec![1, 2]).in_order());
+    // Repeated element / sequences.
+    assert_that!(&[1, 1, 1], contains(vec![1, 1]).in_order());
+    assert_that!(&[1, 2, 1, 2], contains(vec![2, 1, 2]).in_order());
   }
 
   #[test]


### PR DESCRIPTION
The prior `contains_in_order` implementation mishandles inputs that
contain repeated characters. This change:

- Adds some test cases exercising the failure.
- Updates the `contains_in_order` implementation to pass these cases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/valloric/hamcrest2-rust/14)
<!-- Reviewable:end -->
